### PR TITLE
Detect navigation away from login page, rather than to home page

### DIFF
--- a/auth/playwright.go
+++ b/auth/playwright.go
@@ -42,7 +42,7 @@ func Token() (string, error) {
 	// Wait for user to log in
 	for {
 		currentUrl := page.URL()
-		if currentUrl == "https://www.floatplane.com/" {
+		if currentUrl != "https://www.floatplane.com/login" {
 			break
 		}
 		time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
This looks good (minus error handling and commenting and such but that's a future issue to work on), the only thing I'd change right now is how the browser detects navigation. Currently, the code checks if the URL matches a specific one (`https://www.floatplane.com/`) which means that if the user navigates to a different page, closes the page, or FloatPlane changes their main site URL, it will be stuck in an infinite look (unless the user manually navigates to that exact page). However, if we instead wait for the URL to *not match* the login page, we can also detect all of these events and it will still likely work across FloatPlane website changes, unless they change the actual login URL. Eventually it would probably also be good to check for something like `*floatplane.com/login*` to be more flexible in case of URL/subdomain changes, but that's low priority.